### PR TITLE
Add a config file + multiple directories as input 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Options:
                                   The input format
   -of, --output-format [JSON|XML|MD]
                                   The output format
+  -f, --config-file TEXT          Configuration file path
   -c, --category TEXT             Category specifier for XML quizzes
   --help                          Show this message and exit.
 ```
@@ -141,6 +142,29 @@ total 96
 ```
 
 You can see that the questions are saved in a file with the question name as the filename.
+
+## Configuration file format
+
+A configuration file can be provided using the `--config-file` flag.
+
+For instance, we can use:
+
+```console
+python3 src/question_converter.py --config-file config.json
+```
+
+An example `config.json` config file format with all the available fields is:
+
+```json
+{
+  "input-file": "One_Question.md",
+  "input-dirs": ["chapter/io/lab/quiz", "chapter/data/lab/quiz"],
+  "output-file": "Moodle_Questions.xml",
+  "output-dir": "questions",
+  "input-format": "MD",
+  "output-format": "XML"
+}
+```
 
 ## Question Format
 

--- a/src/question_converter.py
+++ b/src/question_converter.py
@@ -23,7 +23,7 @@ def cli():
     "-i", "--input-file", "input_file_path", required=False, help="Input file path"
 )
 @click.option(
-    "-d", "--input-path", "input_dir_path", required=False, help="Input directory (read all `.input_format` files from the input path)"
+    "-d", "--input-path", "input_dir_path", required=False, multiple=True, help="Input directory (read all `.input_format` files from the input path)"
 )
 @click.option(
     "-o", "--output-file", "output_file_path", required=False, help="Output file path"
@@ -53,7 +53,7 @@ def convert(input_file_path, input_dir_path, output_file_path, output_dir_path, 
     """
     Converts files to different formats.
     """
-    if input_file_path is None and input_dir_path is None:
+    if input_file_path is None and input_dir_path == ():
         raise click.UsageError(
             "One of --input-path or --input-file must be set."
         )
@@ -100,8 +100,8 @@ def convert(input_file_path, input_dir_path, output_file_path, output_dir_path, 
         with open(input_file_path, "r", encoding="UTF-8") as input_file:
             input_content = input_file.read().rstrip('\n')
 
-    if input_dir_path is not None:
-        read_files = glob.glob(input_dir_path + "/*.md")
+    for input_dir in input_dir_path:
+        read_files = glob.glob(input_dir + "/*.md")
         for f in read_files:
             with open(f, "rb") as infile:
                 input_content += infile.read().decode("utf-8")

--- a/src/question_converter.py
+++ b/src/question_converter.py
@@ -44,15 +44,39 @@ def cli():
     help="The output format",
 )
 @click.option(
+    "-f",
+    "--config-file",
+    "config_file_path",
+    required=False,
+    help="Configuration file path",
+)
+@click.option(
     "-c",
     "--category",
     required=False,
     help="Category specifier for XML quizzes",
 )
-def convert(input_file_path, input_dir_path, output_file_path, output_dir_path, input_format, output_format, category=None):
+def convert(input_file_path, input_dir_path, output_file_path, output_dir_path, input_format, output_format, config_file_path, category=None):
     """
     Converts files to different formats.
     """
+    if config_file_path is not None:
+        with open(config_file_path, "r") as config_file:
+            config = json.load(config_file)
+
+            if "input-file" in config:
+                input_file_path = config["input-file"]
+            if "input-dirs" in config:
+                input_dir_path += tuple(config["input-dirs"])
+            if "output-file" in config:
+                output_file_path = config["output-file"]
+            if "output-dir" in config:
+                output_dir_path = config["output-dir"]
+            if "input-format" in config and config["input-format"].upper() in ["JSON", "XML", "MD"]:
+                input_format = config["input-format"].upper()
+            if "output-format" in config and config["output-format"].upper() in ["JSON", "XML", "MD"]:
+                output_format = config["output-format"].upper()
+
     if input_file_path is None and input_dir_path == ():
         raise click.UsageError(
             "One of --input-path or --input-file must be set."


### PR DESCRIPTION
PR that implements multiple directories as conversion inputs and a configuration file option.
Issue #3 is addressed.

Suggestion: maybe there should be multiple individual files as conversion inputs too.
The extension detection behavior should be adapted a little bit in this case.